### PR TITLE
Fix board variant references (4.3C → 4.3 dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ A standalone, touchscreen-based RFID programmer for the Creality K2 Plus & CFS (
 
 | Component | Details |
 |-----------|---------|
-| **Board** | Waveshare ESP32-S3 Touch LCD 4.3" (**4.3C** variant) |
+| **Board** | Waveshare ESP32-S3 Touch LCD 4.3" (**development board**) |
 | **Display** | 800×480 RGB LCD, LovyanGFX; touch via GT911 (I2C). Backlight/CTP reset via CH422G (U10). |
 | **RFID** | PN532 (13.56 MHz); MIFARE Classic 1K tags. |
-| **Docs** | [docs/board-variant-4.3C.md](docs/board-variant-4.3C.md) — pinout, schematic, CH422G init. |
+| **Docs** | [docs/board-variant-4.3C.md](docs/board-variant-4.3C.md) — board variant comparison, CH422G init. |
 
 ## 📁 Documentation
 
 | Doc | Description |
 |-----|-------------|
-| [docs/board-variant-4.3C.md](docs/board-variant-4.3C.md) | 4.3C board verification, schematic, LovyanGFX/CH422G notes. |
+| [docs/board-variant-4.3C.md](docs/board-variant-4.3C.md) | Board variant comparison (dev 4.3 vs production 4.3C), CH422G notes. |
 | [docs/CHECKPOINT.md](docs/CHECKPOINT.md) | Checkpoint state, build status, model summary, recent changes. |
 | [docs/CODE-OVERVIEW.md](docs/CODE-OVERVIEW.md) | Module map and data flow (embedded + markdown overview). |
 | [docs/rfid/creality-k2plus-rfid-spec.md](docs/rfid/creality-k2plus-rfid-spec.md) | CFS tag layout and sector usage. |

--- a/boards/waveshare_s3_43.json
+++ b/boards/waveshare_s3_43.json
@@ -29,7 +29,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Waveshare ESP32-S3 Touch LCD 4.3inch (4.3C)",
+  "name": "Waveshare ESP32-S3 Touch LCD 4.3inch (Development Board)",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/docs/CHECKPOINT.md
+++ b/docs/CHECKPOINT.md
@@ -7,7 +7,7 @@
 
 ## Summary
 
-Checkpoint after successful migration to the **4.3C** board (Waveshare ESP32-S3 Touch LCD 4.3") and fixes to the **data model** (FilamentProfile, SpoolData, FilamentDB). **UI layout** evolved to a 3-region main screen; spool widget removed.
+Checkpoint after successful migration to the **4.3 development board** (Waveshare ESP32-S3 Touch LCD 4.3") and fixes to the **data model** (FilamentProfile, SpoolData, FilamentDB). **UI layout** evolved to a 3-region main screen; spool widget removed.
 
 ---
 
@@ -73,7 +73,7 @@ Checkpoint after successful migration to the **4.3C** board (Waveshare ESP32-S3 
 4. **Markdown docs**
    - This checkpoint (`docs/CHECKPOINT.md`).
    - Code overview (`docs/CODE-OVERVIEW.md`).
-   - README updated for 4.3C, PN532, LovyanGFX, LVGL 9.
+   - README updated for 4.3 dev board, PN532, LovyanGFX, LVGL 9.
 
 ---
 

--- a/docs/CODE-OVERVIEW.md
+++ b/docs/CODE-OVERVIEW.md
@@ -10,7 +10,7 @@ High-level map of modules and data flow for K2-RFID-CYD. For in-code details, se
 |------|------|
 | `src/main.cpp` | `setup()`: Serial, LVGL display init, FilamentDB init, config, UIManager; `loop()`: `lv_timer_handler()`, `ui.update()`. |
 | `src/lvgl_display.cpp` | LovyanGFX + LVGL 9 init, display driver, input (touch). |
-| `include/LGFX_Config.h` | Panel/bus/touch config for 4.3C (RGB, GT911). |
+| `include/LGFX_Config.h` | Panel/bus/touch config for 4.3 dev board (RGB, GT911). Works on 4.3C too — same display bus. |
 
 ---
 

--- a/docs/board-variant-4.3C.md
+++ b/docs/board-variant-4.3C.md
@@ -1,62 +1,96 @@
-# Board variant: ESP32-S3-Touch-LCD-4.3C
+# Board Variants: ESP32-S3-Touch-LCD-4.3 (Dev) vs 4.3C (Production)
 
-This project targets the **4.3C** variant of the Waveshare ESP32-S3 Touch LCD 4.3" board.
-
-## How to verify your board is the 4.3C
-
-1. **Schematic**  
-   The repo uses the **4.3C** schematic: `docs/ESP32-S3-Touch-LCD-4.3C-Schematics.pdf`.  
-   If your board matches that schematic (e.g. U10 EXIO expander, EXIO_PWM backlight, IO8/IO9 I2C, EXIO2 = DISP), it is the 4.3C.
-
-2. **Silkscreen / label**  
-   Check the PCB or product label for a model marking such as **ESP32-S3-Touch-LCD-4.3C** or **4.3C**.
-
-3. **Hardware details (4.3C)**  
-   - Backlight: **EXIO_PWM** from U10 (I2C expander), not a direct ESP32 GPIO.  
-   - Touch reset: **EXIO1** (CTP RST) via U10.  
-   - Display control: **EXIO2** = DISP via U10.  
-   - Shared I2C on **IO8 (SDA)** and **IO9 (SCL)** for touch (GT911) and U10.
-
-If your board is 4.3 or 4.3B (different schematic, e.g. direct backlight GPIO), the LGFX and backlight notes in `include/LGFX_Config.h` may not apply; adjust from that board's schematic.
+> **This project targets the 4.3 development board.** This document describes the differences between the two variants and serves as a reference if adapting to the 4.3C.
 
 ---
 
-## Official documentation (how the board is supposed to work)
+## How to identify your board
 
-Waveshare does not publish a separate wiki page for "4.3C"; the **4.3** wiki describes the same hardware family (CH422G, RGB LCD, GT911 touch). Use it as the main reference.
+| Check | 4.3 (Development) | 4.3C (Production / AI Voice) |
+|-------|-------------------|------------------------------|
+| **Silkscreen** | "ESP32-S3-Touch-LCD-4.3" | "ESP32-S3-Touch-LCD-4.3C" |
+| **RS-485 terminal** | Present (SP3485, IO15/IO16) | Not present |
+| **CAN bus terminal** | Present (TJA1051T) | Not present |
+| **Audio codec** | None | ES8311 + ES7210 + NS4150B speaker amp |
+| **RTC** | None | PCF85063A |
+| **Optocoupler I/O (P1)** | None | DOUT0/DOUT1 + DIN0/DIN1 |
+| **Sensor AD header (J6)** | GPIO6 (ADC1_CH5) with ÷3 divider | Not present (GPIO6 = I2S_MCLK) |
+| **Schematic** | `docs/hardware/dev-board-4.3/ESP32-S3-Touch-LCD-4.3-Sch.pdf` | `docs/hardware/production-board-4.3C/ESP32-S3-Touch-LCD-4.3C-Schematics.pdf` |
+
+## What they share
+
+Both variants use the same core hardware:
+
+- **MCU:** ESP32-S3-WROOM-1 (N16R8 — 16 MB flash, 8 MB PSRAM)
+- **Display:** 800×480 RGB LCD (ST7262), 16-bit parallel bus at 12 MHz
+- **Touch:** GT911 capacitive (I2C, GPIO8 SDA / GPIO9 SCL)
+- **I2C Expander:** CH422G (U10) — EXIO1 = TP_RST, EXIO2 = DISP, EXIO4 = SD_CS
+- **Backlight:** Controlled via CH422G EXIO2 (DISP on/off), not a direct ESP32 GPIO
+- **USB-to-UART:** CH343P (upload/monitor port)
+- **Battery charger:** CS8501
+
+The LGFX display bus configuration (`include/LGFX_Config.h`) is identical for both variants — the RGB data pins, HSYNC/VSYNC/DE/PCLK, and GT911 touch all use the same GPIOs.
+
+---
+
+## Official documentation
+
+Waveshare does not publish a separate wiki for "4.3C"; the **4.3** wiki covers the hardware family.
 
 | Resource | URL | Notes |
 |----------|-----|--------|
 | **Waveshare wiki** | [ESP32-S3-Touch-LCD-4.3](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3) | Pinout, CH422G usage, Arduino/ESP-IDF demos, LVGL, FAQ |
-| **Schematic (4.3)** | [ESP32-S3-Touch-LCD-4.3-Sch.pdf](https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3/manual/ESP32-S3-Touch-LCD-4.3-Sch.pdf) | C variant may differ slightly; we use `docs/ESP32-S3-Touch-LCD-4.3C-Schematics.pdf` |
-| **CH422G datasheet** | [CH422DS1_EN.pdf](https://files.waveshare.com/wiki/common/CH422DS1_EN.pdf) | I2C IO expander: EXIO1=TP_RST, EXIO2=DISP, EXIO4=SD_CS, EXIO5=USB_SEL |
-| **ESP LCD FAQ (drift)** | [Why do I get drift…](https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/peripherals/lcd.html#why-do-i-get-drift-overall-drift-of-the-display-when-esp32-s3-is-driving-an-rgb-lcd-screen) | RGB screen shake/drift: PCLK, PSRAM, bounce buffer, `CONFIG_ESP32S3_DATA_CACHE_LINE_64B` |
-| **Waveshare demo pack** | [ESP32-S3-Touch-LCD-4.3-Demo.zip](https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3/ESP32-S3-Touch-LCD-4.3-Demo.zip) | Arduino + ESP-IDF demos; uses `ESP_IOExpander_CH422G`, `ESP_PanelBus_RGB`, GT911 |
-
-From the wiki, the board is supposed to work as follows:
-
-- **Display:** RGB LCD (800×480), driven via ESP32-S3 RGB pins; backlight **on/off** via CH422G **EXIO2 (DISP)** on I2C (GPIO8/9). No direct PWM backlight on the ESP32 for this variant.
-- **Touch:** GT911 on I2C (GPIO8 SDA, GPIO9 SCL); reset via CH422G **EXIO1 (TP_RST)**. TF card CS = **EXIO4 (SD_CS)**.
-- **Libraries (Arduino):** `ESP32_Display_Panel`, `ESP32_IO_Expander` (CH422G); LVGL 8.4 in demos.
-- **Screen drift:** Waveshare points to the [ESP LCD FAQ](https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/peripherals/lcd.html#why-do-i-get-drift-overall-drift-of-the-display-when-esp32-s3-is-driving-an-rgb-lcd-screen) for "screen drifting" (relevant to our "screen shake" issue: PCLK, PSRAM bandwidth, bounce buffer, cache line size).
+| **Dev board schematic** | `docs/hardware/dev-board-4.3/ESP32-S3-Touch-LCD-4.3-Sch.pdf` | Primary reference for this project |
+| **Production schematic** | `docs/hardware/production-board-4.3C/ESP32-S3-Touch-LCD-4.3C-Schematics.pdf` | Reference only |
+| **CH422G datasheet** | `docs/hardware/datasheets/CH422DS1_EN.pdf` | I2C IO expander |
+| **ESP LCD FAQ (drift)** | [Why do I get drift…](https://docs.espressif.com/projects/esp-faq/en/latest/software-framework/peripherals/lcd.html#why-do-i-get-drift-overall-drift-of-the-display-when-esp32-s3-is-driving-an-rgb-lcd-screen) | RGB screen shake/drift: PCLK, PSRAM, bounce buffer |
+| **Waveshare demo pack** | [ESP32-S3-Touch-LCD-4.3-Demo.zip](https://files.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3/ESP32-S3-Touch-LCD-4.3-Demo.zip) | Arduino + ESP-IDF demos |
 
 ---
 
-## Adapting the official approach
+## CH422G (U10) setup
 
-This project uses **LovyanGFX** and **LVGL 9** instead of Waveshare’s **ESP32_Display_Panel** and LVGL 8.x, but we can still use the same **CH422G (U10)** setup as the official demos for touch reset and backlight.
+Both variants use CH422G for display/touch control. This project uses **LovyanGFX** and **LVGL 9** (not Waveshare's ESP32_Display_Panel / LVGL 8.x), but follows the same CH422G init pattern as the official demos.
 
-1. **Add the official IO expander library**  
-   Use [ESP32_IO_Expander](https://github.com/esp-arduino-libs/ESP32_IO_Expander) (Espressif). It supports CH422G and works with Arduino/PlatformIO. Pinout: IO0–IO7 = EXIO0–EXIO7 (e.g. EXIO1 = TP_RST, EXIO2 = DISP); pins 8–11 = OC outputs.
+1. **Add the IO expander library**
+   Use [ESP32_IO_Expander](https://github.com/esp-arduino-libs/ESP32_IO_Expander) (Espressif). Supports CH422G with Arduino/PlatformIO. IO0–IO7 = EXIO0–EXIO7; pins 8–11 = OC outputs.
 
-2. **Init CH422G before the display**  
+2. **Init CH422G before the display**
    Before calling `gfx.begin()`:
    - Create `esp_expander::CH422G` with SCL=9, SDA=8, address `ESP_IO_EXPANDER_I2C_CH422G_ADDRESS`.
-   - Call `init()` then `begin()`. By default `begin()` sets IO0–IO7 as output high, so **EXIO1 (TP_RST)** and **EXIO2 (DISP)** go high — touch out of reset and backlight on.
+   - Call `init()` then `begin()`. Default `begin()` sets IO0–IO7 as output high, so **EXIO1 (TP_RST)** and **EXIO2 (DISP)** go high — touch out of reset and backlight on.
    - Optionally drive a touch-reset sequence (TP_RST low → delay → high) before starting the panel.
 
-3. **Keep our LGFX config**  
-   Our `LGFX_Config.h` stays as-is (LovyanGFX Bus_RGB + Panel_RGB + Touch_GT911, no backlight GPIO). We do not use ESP32_Display_Panel; only the CH422G init is aligned with the official demos.
+3. **Keep LGFX config as-is**
+   `LGFX_Config.h` stays unchanged (LovyanGFX Bus_RGB + Panel_RGB + Touch_GT911, no backlight GPIO). Only the CH422G init is aligned with the official demos.
 
-4. **Brightness (optional)**  
-   EXIO_PWM (U10 pin 10) can be used for backlight dimming later if the CH422G driver or a small custom I2C layer supports it; for now DISP on/off via EXIO2 is enough.
+---
+
+## Dev board specifics (4.3)
+
+Features available on the dev board that are **not** on the 4.3C:
+
+- **RS-485** (SP3485): IO15 (TX) / IO16 (RX) — usable as general GPIO when RS-485 terminal is disconnected
+- **CAN bus** (TJA1051T): Directly connected to ESP32-S3 TWAI peripheral
+- **USB host switch** (FSUSB42UMX): EXIO5 selects between USB-to-UART and USB host
+- **Sensor AD** (J6 header): GPIO6 / ADC1_CH5 with on-board ÷3 voltage divider — used for battery monitoring
+- **CH422G OC outputs** (OC0–OC3): Open-collector outputs available for feedback hardware (buzzer, LEDs)
+
+## 4.3C-only features (not available on dev board)
+
+- **Audio:** ES8311 DAC + ES7210 ADC + NS4150B speaker amplifier (I2S on GPIO6/GPIO15/GPIO16)
+- **RTC:** PCF85063A (I2C, shared bus)
+- **Optocoupler I/O:** DOUT0/DOUT1 digital outputs, DIN0/DIN1 digital inputs via P1 header
+- **EXIO_ADC:** Battery voltage via CH422G (instead of GPIO6 Sensor AD)
+
+---
+
+## Adapting between variants
+
+If porting this project to the 4.3C:
+
+1. **GPIO6 conflict:** GPIO6 is I2S_MCLK on 4.3C (audio), not Sensor AD. Battery monitoring must use EXIO_ADC instead.
+2. **IO15/IO16 conflict:** These are I2S BCLK/LRCK on 4.3C (audio), not RS-485. Cannot use as general GPIO.
+3. **Feedback hardware:** Use P1 header DOUT0/DOUT1 (optocouplers) instead of CH422G OC0–OC3.
+4. **RTC available:** Can use PCF85063A for timestamps instead of NTP.
+5. **I2C bus:** 6 devices on 4.3C (GT911, CH422G, PN532, ES8311, ES7210, PCF85063A) vs 3 on dev (GT911, CH422G, PN532). May need lower bus speed or careful arbitration.

--- a/src/ui/screens/screen_about.cpp
+++ b/src/ui/screens/screen_about.cpp
@@ -71,7 +71,7 @@ void ScreenAbout::show() {
 
     // --- Populate Labels ---
 #ifdef BOARD_ESP32_S3_TOUCH_LCD_4_3C
-    lv_label_set_text(labelBoard, "Board: ESP32-S3-Touch-LCD-4.3C");
+    lv_label_set_text(labelBoard, "Board: ESP32-S3-Touch-LCD-4.3 (Dev)");
 #else
     lv_label_set_text(labelBoard, "Board: (see build)");
 #endif


### PR DESCRIPTION
## Summary
- Corrected all stale references that identified the target board as the 4.3C production variant — the actual target is the **4.3 development board**
- Rewrote `docs/board-variant-4.3C.md` from a "how to verify your 4.3C" doc into a comprehensive **variant comparison guide** (dev 4.3 vs production 4.3C)
- Updated board name in PlatformIO board definition (`boards/waveshare_s3_43.json`)
- Fixed About screen label in `screen_about.cpp`
- Updated references in README, CHECKPOINT, and CODE-OVERVIEW

## Files changed (6)
- `README.md` — Board table and docs table entries
- `boards/waveshare_s3_43.json` — Board name field
- `docs/board-variant-4.3C.md` — Full rewrite as variant comparison
- `docs/CHECKPOINT.md` — Summary and changelog references
- `docs/CODE-OVERVIEW.md` — LGFX_Config description
- `src/ui/screens/screen_about.cpp` — Display string

## Test plan
- [ ] Verify `pio run` builds successfully with updated board JSON
- [ ] Confirm About screen shows "Board: ESP32-S3-Touch-LCD-4.3 (Dev)"
- [ ] Review board-variant-4.3C.md for accuracy against schematics

🤖 Generated with [Claude Code](https://claude.com/claude-code)