### PR TITLE
fix: Milestone 1 — Hardware-Stable Core complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ WiFi, RFID (Auto-Read), and sound (GPIO19) are fully active and integrated into 
 | **RFID** | `src/rfid_driver.cpp`, `include/rfid_driver.h` | PN532 driver; Key A derivation from UID; `readCFSTag()`/`writeCFSTag()` |
 | **UIManager** | `src/ui/ui_manager.cpp` | Screen management, event handling, `currentSpool`, color picker, `updateDashboardFromSpool()` |
 | **Screens** | `src/ui/screens/screen_*.cpp` | Main (3-region layout), Library (filament grid), Settings, About, Filament Select |
-| **Config** | `src/config_manager.cpp` | Persistent config (beep, brightness, WiFi) via LittleFS `config.json` |
+| **Config** | `src/config_manager.cpp` | Persistent config (beep, WiFi) via LittleFS `config.json` |
 | **Network** | `src/network_manager.cpp` | WiFiManager portal, filament DB updates |
 | **State** | `src/system_state.cpp` | SystemState/SystemEvent enums with StateMachine transitions |
 
@@ -78,7 +78,7 @@ Entire string uppercased. Brand and filament name are **not stored** on tag. `Sp
 Sectors 0-15, 4 blocks/sector, 16 bytes/block. Key A derived from UID. Sectors 1-4 immutable (magic, identity, color, vendor), sector 5 write-once (initial weight), sectors 6-8 mutable mirrors (remaining filament), sector 9 usage counters, sector 15 CRC32. Full spec: `docs/rfid/creality-k2plus-rfid-spec.md`.
 
 ### App config (`config.json` on LittleFS)
-JSON with `beep_enabled`, brightness, WiFi SSID. Managed by `ConfigManager`.
+JSON with `beep_enabled`, WiFi SSID. Managed by `ConfigManager`.
 
 ## Key Conventions
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,98 +14,90 @@ clean boot output.
 
 Issues collected 2026-03-10 by walking through the physical device. Ordered by impact and dependency.
 
-### Step 1 — Fix Issue #9: PN532 invalid pin log errors (cosmetic, low risk)
+### ~~Step 1 — Fix Issue #9: PN532 invalid pin log errors~~ ✅ DONE
 
-**Symptom:** Two `Invalid pin selected` messages at boot from the PN532 constructor.
-**Root cause:** `PN532_IRQ` and `PN532_RESET` are defined as `(-1)` (int). `Adafruit_PN532` constructor
-takes `uint8_t`, so -1 silently becomes 255 (0xFF). Arduino HAL's `__pinMode(255)` logs the error.
-RFID still functions — cosmetic only.
-**Fix:** Change defines to `(0xFF)` (the documented "no pin" sentinel for this library), or guard
-`__pinMode` calls with a valid-pin check.
+**Fix applied in `b8edfba`:** `PN532_IRQ` and `PN532_RESET` changed to `(0xFF)` in `src/rfid_driver.cpp`.
 
 ---
 
-### Step 2 — Fix Issues #3 & #7: State machine UI lockout (no ERROR→IDLE recovery)
+### ~~Step 2 — Fix Issues #3 & #7: State machine UI lockout~~ ✅ DONE
 
-**Symptom #3:** Any RFID auth failure → `State: -> ERROR` → all buttons ghosted except Settings→About.
-Only fix is reboot.
-**Symptom #7:** Settings → Update Database → `State: -> UPDATING DB` → `State: -> ERROR` → same total
-UI lockout.
-**Root cause:** Both paths share the same bug: the `ERROR` state in the state machine has no exit
-transition back to `IDLE`. `updateButtonStates()` disables all action buttons in ERROR state with no
-dismiss / retry path wired to the UI.
-**Fix:** (a) Add `ERROR → IDLE` transition triggered by a dismiss tap or a timeout. (b) Wire a visible
-"Dismiss" / "Retry" button or status-bar tap to fire it. (c) Ensure `updateButtonStates()` re-enables
-controls once back in IDLE.
+**What was already in place:** ERROR→IDLE transitions (USER_DISMISS, USER_RETRY, TIMEOUT) in state
+machine; `tick()` auto-dismiss; `labelWriteStatus` tap-to-dismiss on Main; `loop()` calls `tick()` and
+re-enables buttons.
 
----
-
-### Step 3 — Fix Issue #2: RFID Key A authentication failure on real Creality spool
-
-**Symptom:** Auto-read detects tag `F5:A7:68:19` but fails: `Auth failed for sector 1`.
-**Root cause (suspected):** `generateKeyA()` passes the raw UID buffer (4–7 bytes) directly to
-`mbedtls_aes_crypt_ecb()` which requires a full 16-byte input block. The remaining bytes are whatever
-is on the stack — a buffer overread producing a wrong key, hence auth failure.
-**Fix:** Zero-pad the UID into a 16-byte array before calling AES-ECB. Verify the derivation scheme
-against the Creality K2 Plus RFID spec (`docs/rfid/creality-k2plus-rfid-spec.md`) to confirm the
-correct key input format (some implementations XOR or hash additional fields before AES).
+**Remaining gaps fixed (2026-03-20):**
+- `showMainScreen()` now preserves the status label in ERROR state instead of resetting to "Ready".
+- DB update failure (`Issue #7`): after `DB_UPDATE_FAILED`, error message is shown on `labelWriteStatus`
+  and UI navigates to Main so the user can see it (shown in red) and tap to dismiss. Previously the
+  Settings screen buttons went grey for 15 s with no visual feedback.
 
 ---
 
-### Step 4 — Fix Issue #1: Splash screen WiFi status not displayed
+### ~~Step 3 — Fix Issue #2: RFID Key A authentication failure on real Creality spool~~ ✅ DONE
 
-**Symptom:** Splash shows but WiFi connection status label is blank / not updating. No "Continue"
-button visible. Feature was working in the Gemini session that created it.
-**Likely cause:** Event callback or label update path broken during the board migration merge; status
-labels may not have been wired to the WiFi state callbacks, or the 10-second hold timer fires before
-the labels populate.
-**Fix:** Trace WiFi status → splash label update path; confirm `screen_wifi` / splash status labels
-are populated on `NETWORK_CONNECTED` / `NETWORK_FAILED` events; confirm Continue button is shown and
-tap navigates to main screen.
+**Code fix already in place** (see `generateKeyA()` comment block, rfid_driver.cpp:940–964):
+- UID is cycled into a 16-byte `input[16]` buffer (`uid[i % currentUidLen]`) — no stack overread.
+- Separate `aes_out[16]` used for AES output; only 6 bytes copied to `keyOut` — no overflow.
+- Algorithm matches DnG-Crafts/K2-RFID Utils.cs CreateKey() reference (cycling, not zero-pad).
+- Auth log now prints UID + derived key on one line for cross-checking with reference tools.
 
----
-
-### Step 5 — Fix Issue #8: First-boot .tmp file errors for config.json / inventory.json
-
-**Symptom:** On first boot (no existing files), both `config.json` and `inventory.json` log
-"does not exist" errors during `.tmp` recovery.
-**Root cause:** `recoverTmpFile()` calls `LittleFS.exists()` on the `.tmp` path — if neither the base
-file nor the `.tmp` exists, the error is benign but noisy. The atomic-write pattern assumes at least
-one of the two files exists.
-**Fix:** Guard `recoverTmpFile()` with an existence check; on first boot, silently skip recovery and
-proceed to create the file from defaults. No functional impact after boot; this is a log-cleanliness
-fix.
+**Confirmed on hardware:** Spool successfully read in a prior session. Key A derivation correct.
 
 ---
 
-### Step 6 — Fix Issue #6: Audio feedback silent on RFID read/write
+### ~~Step 4 — Fix Issue #1: Splash screen WiFi status not displayed~~ ✅ DONE
 
-**Symptom:** RFID read/write completes (or fails) with no audio. Board is V3.1 with onboard speaker.
-**Context:** `uiSound.init()` must be called in `setup()` with the correct path for V3.1. V3.1 uses
-I2S (same as V2.0 path; build flag `-DBOARD_MATOUCH_V2` enables it). `playClick()` / `playStartup()`
-calls may be commented out or the feedback module may call legacy GPIO buzzer functions instead of
-`uiSound`.
-**Fix:** Confirm `-DBOARD_MATOUCH_V2` in `platformio.ini` for the V3.1 env. Confirm `uiSound.init()`
-called in `setup()`. Wire feedback module events (`RFID_READ_OK`, `RFID_READ_FAIL`, etc.) to
-`uiSound.playClick()` / tone sequences.
-**Future (non-blocking):** Add a distinct ascending scale melody on successful read, descending on
-failure, and a random short progression on boot. Log as enhancement once base audio is working.
+**Label update path:** Already working — `lv_tick_set_cb(millis)` ensures LVGL tick advances during
+`setup()` so `lv_timer_handler()` actually flushes dirty areas. Each `splash_update_status()` call
+already invokes `lv_timer_handler()`.
+
+**Continue button (2026-03-20):** Implemented in `lvgl_display.cpp`:
+- `splash_show_continue_button()` creates a tappable button on the splash screen.
+- `splash_is_continue_pressed()` returns true when tapped.
+- `setup()` calls `splash_show_continue_button()` after all 4 status items are populated.
+- The 10-second hold loop breaks immediately on tap; auto-advances at 10 s if not tapped.
 
 ---
 
-### Step 7 — Fix Issues #4 & #5: About screen live status + investigate low heap
+### ~~Step 5 — Fix Issue #8: First-boot .tmp file errors~~ ✅ DONE (already correct)
 
-**Issue #4:** About screen shows only static hardware specs. Should show live WiFi SSID/IP and RFID
-connection status at minimum.
-**Fix:** Add two live-status labels to `ScreenAbout::show()` populated from `network.isConnected()` /
-`network.getSSID()` / `network.getIP()` and `rfid.isInitialized()`. Call `show()` each time the
-screen is loaded (already the pattern).
+`recoverTmpFile()` opens with `if (!LittleFS.exists(tmpPath.c_str())) return;` — silently returns
+when neither the base file nor its `.tmp` exists (first boot). `ConfigManager::load()` silently calls
+`save()` when `/config.json` is absent. `InventoryManager::init()` logs an informational
+"No inventory.json found, starting empty." (not an error) before creating defaults. No log noise.
 
-**Issue #5:** Heap free reported as ~78KB — suspiciously low for a device with 512KB SRAM and 8MB PSRAM.
-**Investigate:** Check whether LVGL draw buffers, ArduinoJson doc, and PSRAM allocations are correctly
-routed to PSRAM. Check for heap fragmentation. Log `ESP.getFreeHeap()`, `ESP.getFreePsram()`,
-`ESP.getMinFreeHeap()` at startup and after each major init step. 78KB heap may be normal if most
-working memory is in PSRAM — need to confirm PSRAM free is healthy first.
+---
+
+### ~~Step 6 — Fix Issue #6: Audio feedback silent on RFID read/write~~ ✅ DONE
+
+Three root causes fixed (2026-03-20):
+1. **`-DBOARD_MATOUCH_V2` added to `platformio.ini`** — activates I2S UISound path (GPIO2/19/20),
+   sets `FEEDBACK_HARDWARE_ENABLED=0`, disables backlight PWM (V3.1 hardware always-on like V2.0).
+   Also added `-DBOARD_MATOUCH_V31` marker for future conditionals.
+2. **`uiSound.init()` + `uiSound.playStartup()` uncommented** in `setup()` — I2S now initialises and
+   plays the three-note startup melody on boot.
+3. **`feedback.cpp` wired to `uiSound`** for all event methods when `FEEDBACK_HARDWARE_ENABLED=0`:
+   - `readSuccess` / `tagDetected` / `spoolSaved` → short tones / click
+   - `writeSuccess` / `dbUpdateSuccess` → ascending A5→E6 pair
+   - `operationFailed` / `dbUpdateFailed` → low E4 tone (400 ms)
+   All respect `config.data.beep_enabled`. V1.3 GPIO buzzer path is unchanged.
+
+---
+
+### ~~Step 7 — Fix Issues #4 & #5: About screen live status + investigate low heap~~ ✅ DONE
+
+**Issue #4 fix (2026-03-20):** Added `labelWifiStatus` and `labelRFIDLive` to `ScreenAbout::show()`:
+- WiFi: shows SSID + IP in green, or "Not connected" in red — via `network.isConnected()` / `WiFi.SSID()` / `WiFi.localIP()`.
+- RFID: shows "PN532 OK | IC=0x32 ver=1.6" in green, or "not found" in red — via `rfid.getFirmwareVersion()`.
+- Memory line now shows PSRAM free KB alongside total.
+
+**Issue #5 resolved (2026-03-20):** Per-step heap/PSRAM logging added to `setup()`. Observed on hardware:
+- PSRAM free ≈ 7424KB (out of ~7MB reported usable) — all large allocations correctly in PSRAM.
+- Internal heap free ≈ 68KB — normal for ESP32-S3 at this boot stage; FreeRTOS + Arduino overhead
+  accounts for the difference. No fragmentation concern.
+- **Verdict: memory is healthy.** 68KB internal heap is not low — it's expected when PSRAM carries
+  the working set.
 
 ---
 
@@ -133,6 +125,8 @@ working memory is in PSRAM — need to confirm PSRAM free is healthy first.
 - [x] **FilamentDB** — 40 profiles loaded from LittleFS `material_database.json`. ArduinoJson v7.
 - [x] **P0 + P1 FSD tiers implemented** (code exists; real-hardware validation in progress per
   Milestone 1 bug fixes above).
+- [x] **Issue #9 — PN532 invalid pin log errors** — `PN532_IRQ`/`PN532_RESET` set to `0xFF` sentinel
+  (`b8edfba`). No more `Invalid pin selected` boot noise.
 
 ---
 
@@ -152,6 +146,9 @@ Fix all 9 active bugs (Step 1–7 above). Exit criteria:
 - CRC32 and mirror sectors written and validated on read-back
 - SpoolData fields (date code, vendor, material, color, length, serial) round-trip correctly
 - State transitions: IDLE → READING/WRITING → IDLE (no lockout, no stale state)
+- **Remaining grams on main screen:** After auto-read, surface `rfid.getLastMirrors()` data
+  (`remain_weight_g`) on the dashboard so users can see current vs original weight at a glance.
+  Mirror sectors use the standard MIFARE key (confirmed 2026-03-20 on Creality spool).
 
 ### Milestone 3 — Inventory Flow
 - Scan tag → SpoolRecord auto-added to inventory (or reconciled if UID already exists)
@@ -163,9 +160,28 @@ Fix all 9 active bugs (Step 1–7 above). Exit criteria:
 ### Milestone 4 — Polish & Completeness
 - Audio feedback: distinct tones for read-ok / write-ok / error / low-battery; boot melody
 - About screen: live WiFi SSID/IP + RFID status (Issue #4)
-- Settings screen: brightness slider, beep on/off toggle both functional
+- Settings screen: beep on/off toggle functional
 - Sleep mode: screen timeout + wake on touch (GT911 interrupt)
 - Memory audit: PSRAM usage confirmed healthy (Issue #5), heap budget documented
+- **Multi-brand support:** Our current `material_database.json` only contains Creality and
+  Generic (2 brands). The K2-RFID project's database includes third-party brands (eSUN
+  confirmed). Two work items:
+  1. **Replace/expand the DB file:** Source the fuller K2-RFID material database which
+     includes eSUN and other brands. Re-upload to LittleFS (`pio run -t uploadfs`).
+  2. **Library UI:** Brand filter/dropdown must enumerate brands dynamically from
+     `FilamentProfile.brand` — not hardcoded — so new brands appear automatically.
+  3. **RFID read brand mapping:** Only vendor ID `0276` → Creality is currently mapped.
+     Add known third-party vendor IDs as discovered. Unknown IDs show raw ID + allow
+     user assignment via Custom Spool Entry.
+  Brands confirmed needed: Creality, eSUN, GREETECH, Generic (fallback).
+- **Filament specs in UI (temps):** Surface `nozzle_temp` / `bed_temp` from `FilamentProfile`
+  on the dashboard and spool detail screen for library-picked spools.
+  - Creality v1 RFID tags do NOT store temps on-tag (CFS payload has no temp fields).
+  - Our v2 tag format stores temps in sector 10 (`ExtTempBlock`: nozzle min/max/default,
+    bed min/max/default) — populated when writing a tag from a library profile.
+  - On scan: if tag is v2 + has our origin magic, read temps from sector 10; otherwise
+    fall back to DB lookup by material type (best-effort match).
+  - Custom Spool Entry wizard needs nozzle temp + bed temp input fields.
 
 ### Milestone 5 — Production Prep *(stretch / future)*
 - Battery monitoring via GPIO6 ADC (voltage-to-SoC table; low-battery state)
@@ -173,6 +189,21 @@ Fix all 9 active bugs (Step 1–7 above). Exit criteria:
 - V3.1 I2S audio path confirmed (currently using V2.0 path as proxy)
 - OTA database update from printer HTTP API tested end-to-end
 - P2 FSD items: I2C bus recovery (P2.1), string length enforcement (P2.6), memory monitoring (P2.5)
+
+### Milestone 6 — Bambu Lab NFC Read *(stretch)*
+- Bambu Lab AMS spools use **NFC Forum Type 2 tags** (NTAG213/215), not MIFARE Classic.
+  The PN532 can read these in passive mode — no Key A auth required.
+- Tag format is community-reverse-engineered (not officially documented by Bambu Lab).
+  Reference: community work at github.com/Bambu-Research-Group/RFID-Tag-Guide
+- **Read-only goal:** detect tag type on scan, parse Bambu payload (material type, color,
+  min/max temps, spool weight) and display on dashboard — same UX as a Creality spool read.
+- No write support planned (Bambu tags are write-locked after factory programming).
+- Implementation notes:
+  - `checkTagPresent()` already calls `readPassiveTargetID()`; NTAG returns ATQA 0x0044
+    (vs MIFARE Classic 0x0002/0x0004) — use this to branch tag-type detection.
+  - Add `detectTagType()` → enum `{TAG_MIFARE_CLASSIC, TAG_NTAG, TAG_UNKNOWN}`.
+  - Add `readBambuTag(SpoolData& out)` in rfid_driver using `ntag2xx_ReadPage()`.
+  - Map Bambu material codes + color to `SpoolData` fields for unified inventory flow.
 
 ---
 
@@ -187,4 +218,4 @@ Fix all 9 active bugs (Step 1–7 above). Exit criteria:
 
 ---
 
-*Last updated: 2026-03-10*
+*Last updated: 2026-03-20*

--- a/docs/rfid/creality-k2plus-rfid-spec.md
+++ b/docs/rfid/creality-k2plus-rfid-spec.md
@@ -259,7 +259,14 @@ A compliant tag MUST:
     - Update CRC coverage rules if needed
 
 ---
-# 11. Repository Recommendation
+# 11. External References
+
+- **SimplyPrint — The Creality Material Standard (NFC/RFID for the Creality CFS)**
+  https://help.simplyprint.io/en/article/the-creality-material-standard-nfcrfid-for-the-creality-cfs-1crrofa/
+  Community documentation of the CFS payload format, sector layout, and Key A derivation.
+  Cross-reference against this spec when verifying field offsets or encoding rules.
+
+# 12. Repository Recommendation
 
 Suggested path:
 ```

--- a/include/config_manager.h
+++ b/include/config_manager.h
@@ -6,7 +6,6 @@ struct AppConfig {
     bool beep_enabled = true;
     bool write_empty_only = true;
     bool clone_serial = false;
-    uint8_t brightness = 255;
     String printer_ip = "192.168.1.100";
 
     // P1.10: Database update metadata (FSD Section 5.6)

--- a/include/rfid_driver.h
+++ b/include/rfid_driver.h
@@ -104,6 +104,9 @@ public:
     // Get last decoded CFS payload string (40-char uppercase ASCII, shown in table)
     const char* getLastPayload() const;
 
+    // Get mirror result from the last readCFSTag() call (sectors 6-8, remaining filament)
+    const MirrorResult& getLastMirrors() const;
+
 private:
     Adafruit_PN532* nfc;
 

--- a/include/ui/screens/screen_about.h
+++ b/include/ui/screens/screen_about.h
@@ -19,6 +19,8 @@ private:
     lv_obj_t* labelMemInfo;
     lv_obj_t* labelFlashInfo;
     lv_obj_t* labelStorageInfo;
+    lv_obj_t* labelWifiStatus;
+    lv_obj_t* labelRFIDLive;
 };
 
 extern ScreenAbout screenAbout;

--- a/include/ui/screens/screen_main.h
+++ b/include/ui/screens/screen_main.h
@@ -7,6 +7,7 @@ public:
     void show();
     void update(const class SpoolData& data);
     void setWriteStatus(const char* status, bool success = false, bool neutral = true);
+    void updateStatusBar(bool wifiConnected, int8_t rssi, const char* ssid);
 
     lv_obj_t* screen;
     lv_obj_t* btnSettings;
@@ -19,8 +20,13 @@ public:
     lv_obj_t* labelName;
     lv_obj_t* ddBrand;
     lv_obj_t* ddType;
-    lv_obj_t* colorBlock;     /* colored block, tap opens color picker */
-    lv_obj_t* labelHexColor;  /* hex/name label inside colorBlock */
+    lv_obj_t* colorBlock;       /* colored block, tap opens color picker */
+    lv_obj_t* labelHexColor;    /* hex/name label inside colorBlock */
+
+    // Status bar (top 24px row)
+    lv_obj_t* statusBar;
+    lv_obj_t* labelBattStatus;  /* battery placeholder icon */
+    lv_obj_t* labelWifiStatus;  /* wifi icon + SSID/state */
 };
 
 extern ScreenMain screenMain;

--- a/include/ui/ui_manager.h
+++ b/include/ui/ui_manager.h
@@ -53,6 +53,7 @@ public:
     void showRfidRawScreen();
 
     void updateDashboardFromSpool(const SpoolData& data);
+    void updateStatusBar(bool wifiConnected, int8_t rssi, const char* ssid);
 
     // P1.9: Operation lock & UI guards (FSD Section 12.5)
     void updateButtonStates();  // Enable/disable buttons based on sysState

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,9 @@ build_flags =
     -DLV_CONF_SUPPRESS_DEFINE_CHECK
     -DBOARD_HAS_PSRAM
     -std=gnu++17
+    -DBOARD_MATOUCH_V2       ; V3.1: I2S audio on GPIO2(LRCLK)/GPIO19(DIN)/GPIO20(BCLK);
+                              ;        backlight hardware always-on (same as V2.0).
+    -DBOARD_MATOUCH_V31      ; V3.1 marker for any future V3.1-specific conditionals.
 
 ; Crucial for S3 OPI PSRAM models
 board_build.arduino.memory_type = qio_opi

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -37,7 +37,6 @@ void ConfigManager::load() {
     data.beep_enabled = doc["beep"] | true;
     data.write_empty_only = doc["write_empty"] | true;
     data.clone_serial = doc["clone_serial"] | false;
-    data.brightness = doc["brightness"] | 255;
     data.printer_ip = doc["printer_ip"] | "192.168.1.100";
 
     // P1.10: DB update metadata
@@ -53,7 +52,6 @@ void ConfigManager::save() {
     doc["beep"] = data.beep_enabled;
     doc["write_empty"] = data.write_empty_only;
     doc["clone_serial"] = data.clone_serial;
-    doc["brightness"] = data.brightness;
     doc["printer_ip"] = data.printer_ip;
 
     // P1.10: DB update metadata

--- a/src/feedback.cpp
+++ b/src/feedback.cpp
@@ -1,5 +1,6 @@
 #include <feedback.h>
 #include <config_manager.h>
+#include <ui/ui_sound.h>
 
 Feedback feedback;
 
@@ -68,44 +69,86 @@ void Feedback::update() {
 }
 
 // --- High-level patterns (FSD Section 9.4) ---
+//
+// Hardware routing:
+//   FEEDBACK_HARDWARE_ENABLED=1 (V1.3): non-blocking GPIO buzzer + LED patterns.
+//   FEEDBACK_HARDWARE_ENABLED=0 (V2.0/V3.1): blocking I2S tones via uiSound.
+//     Blocking is acceptable here — all calls happen after an operation completes.
+//     Tone pairs use ascending (success) or low (fail) frequencies.
+
+#if !FEEDBACK_HARDWARE_ENABLED
+// Helper: play a sound if beep is enabled. Used by all V2.0/V3.1 event methods.
+static void playIfEnabled(int freqHz, int durationMs) {
+    if (config.data.beep_enabled) uiSound.playTone(freqHz, durationMs);
+}
+#endif
 
 void Feedback::readSuccess() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    playIfEnabled(880, 100);                         // A5 — short confirm
+#endif
     startBeepPattern(1, 100, 0);
     ledGreen(true);
     _greenOffAt = millis() + 1000;
 }
 
 void Feedback::writeSuccess() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    if (config.data.beep_enabled) {
+        uiSound.playTone(880, 100);                  // A5
+        delay(60);
+        uiSound.playTone(1320, 120);                 // E6 — ascending pair
+    }
+#endif
     startBeepPattern(2, 100, 100);
     ledGreen(true);
     _greenOffAt = millis() + 1500;
 }
 
 void Feedback::operationFailed() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    playIfEnabled(330, 400);                         // E4 — low, longer
+#endif
     startBeepPattern(1, 500, 0);
     ledRed(true);
     _redOffAt = millis() + 2000;
 }
 
 void Feedback::tagDetected() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    if (config.data.beep_enabled) uiSound.playClick();
+#endif
     startBeepPattern(1, 50, 0);
     ledGreen(true);
     _greenOffAt = millis() + 200;
 }
 
 void Feedback::spoolSaved() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    if (config.data.beep_enabled) uiSound.playClick();
+#endif
     startBeepPattern(1, 100, 0);
     ledGreen(true);
     _greenOffAt = millis() + 500;
 }
 
 void Feedback::dbUpdateSuccess() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    if (config.data.beep_enabled) {
+        uiSound.playTone(880, 100);
+        delay(60);
+        uiSound.playTone(1320, 120);
+    }
+#endif
     startBeepPattern(2, 100, 100);
     ledGreen(true);
     _greenOffAt = millis() + 1000;
 }
 
 void Feedback::dbUpdateFailed() {
+#if !FEEDBACK_HARDWARE_ENABLED
+    playIfEnabled(330, 400);
+#endif
     startBeepPattern(1, 500, 0);
     ledRed(true);
     _redOffAt = millis() + 2000;

--- a/src/lvgl_display.cpp
+++ b/src/lvgl_display.cpp
@@ -12,6 +12,8 @@ LV_IMG_DECLARE(logo_thingy);
 static LGFX gfx;
 static lv_obj_t* splash_screen;
 static lv_obj_t* status_container;
+static lv_obj_t* continue_btn = nullptr;
+static bool      continue_pressed = false;
 static int status_label_count = 0;
 
 static void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
@@ -39,8 +41,15 @@ void my_touch_read(lv_indev_t *indev, lv_indev_data_t *data) {
 
 void lvgl_display_init() {
     gfx.begin();
-    gfx.fillScreen(TFT_BLACK); 
+    gfx.fillScreen(TFT_BLACK);
     lv_init();
+
+    // Wire LVGL's tick to Arduino millis() so the display refresh timer
+    // fires correctly during setup() — not just in loop().  Without this,
+    // lv_tick_get() returns 0 throughout setup(), the 30 ms refr period
+    // never elapses, dirty areas never flush, and the splash status labels
+    // are never rendered to the physical display until loop() starts.
+    lv_tick_set_cb([]() -> uint32_t { return (uint32_t)millis(); });
 
     const uint32_t buf_pixels = (gfx.width() * gfx.height()) / 12;
     const uint32_t buf_size_bytes = buf_pixels * sizeof(lv_color_t);
@@ -99,5 +108,24 @@ void splash_update_status(int index, const char* status_text, bool success) {
 }
 
 void lvgl_display_start_ui() {}
-bool splash_is_continue_pressed() { return true; } // Always true to skip loop
-void splash_show_continue_button() {}
+
+bool splash_is_continue_pressed() { return continue_pressed; }
+
+void splash_show_continue_button() {
+    if (continue_btn) return;  // already created
+
+    continue_btn = lv_btn_create(splash_screen);
+    lv_obj_set_size(continue_btn, 200, 50);
+    lv_obj_align(continue_btn, LV_ALIGN_BOTTOM_MID, 0, -10);
+
+    lv_obj_t* lbl = lv_label_create(continue_btn);
+    lv_label_set_text(lbl, "Continue");
+    lv_obj_set_style_text_font(lbl, &lv_font_montserrat_18, 0);
+    lv_obj_set_align(lbl, LV_ALIGN_CENTER);
+
+    lv_obj_add_event_cb(continue_btn, [](lv_event_t*) {
+        continue_pressed = true;
+    }, LV_EVENT_CLICKED, NULL);
+
+    lv_timer_handler();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,6 +188,15 @@ void loop() {
     network.process();
     rfid_task(); // 🟢 Run the auto-detection task
 
+    // Update status bar (battery placeholder + WiFi) every 2 seconds
+    static uint32_t last_status_ms = 0;
+    if (now - last_status_ms >= 2000) {
+        bool wifiOk = network.isConnected();
+        int8_t rssi  = wifiOk ? (int8_t)WiFi.RSSI() : 0;
+        ui.updateStatusBar(wifiOk, rssi, wifiOk ? WiFi.SSID().c_str() : nullptr);
+        last_status_ms = now;
+    }
+
     // If we are in WiFi Config state and just connected, wrap up and return to settings
     if (sysState.getCurrentState() == SystemState::WIFI_CONFIG && network.isConnected()) {
         Serial.println("WiFi Connected! Exiting config portal...");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include <rfid_driver.h>
 #include <Wire.h>
 #include <feedback.h>
+#include <ui/ui_sound.h>
 #include <ui/screens/screen_about.h>
 #include "board_pins.h"
 
@@ -25,20 +26,23 @@ void setup() {
     Serial.begin(115200);
     delay(500);
     Serial.println("--- Booting ---");
+    Serial.printf("Mem[boot]:    heap=%u  psram=%u  minHeap=%u\n",
+                  ESP.getFreeHeap(), ESP.getFreePsram(), ESP.getMinFreeHeap());
 
     // Initialize WDT early to handle boot load
-    esp_task_wdt_init(10, true); 
+    esp_task_wdt_init(10, true);
     esp_task_wdt_add(NULL);
 
     // 1. Initialize display and show splash
     lvgl_display_init();
     Serial.println("Splash Screen Initialized");
+    Serial.printf("Mem[display]: heap=%u  psram=%u\n", ESP.getFreeHeap(), ESP.getFreePsram());
 
     // --- Initialize Sound ---
-    // V1.3: passive buzzer on Mabee GPIO1 (GPIO19). V2.0: I2S on GPIO2/19/20.
-    // Uncomment once audio hardware is connected and board version confirmed.
-    // uiSound.init();
-    // uiSound.playStartup();
+    // V3.1/V2.0: I2S DAC on GPIO2(LRCLK)/GPIO19(DIN)/GPIO20(BCLK) — onboard SPK connector.
+    // Enabled via -DBOARD_MATOUCH_V2 build flag.
+    uiSound.init();
+    uiSound.playStartup();
 
     // 2. Add status labels
     splash_add_status("WiFi", false);
@@ -66,20 +70,30 @@ void setup() {
     uint32_t rfid_ver = rfid.getFirmwareVersion();
     bool rfid_ok = rfid_ver > 0;
     Serial.printf("RFID: %s (ver=0x%08X)\n", rfid_ok ? "OK" : "NOT FOUND", rfid_ver);
+    Serial.printf("Mem[rfid]:    heap=%u  psram=%u\n", ESP.getFreeHeap(), ESP.getFreePsram());
     splash_update_status(1, rfid_ok ? "Available" : "Not Found", rfid_ok);
 
     // For now, let's assume Bluetooth is available if the code compiles
     splash_update_status(2, "Available", true);
     bool db_ok = filamentDB.init();
+    Serial.printf("Mem[filamentDB]: heap=%u  psram=%u\n", ESP.getFreeHeap(), ESP.getFreePsram());
     splash_update_status(3, db_ok ? "Loaded" : "Failed", db_ok);
 
-    // 4. Force a 10-second pause to show final connection status
-    Serial.println("Booting: holding splash screen for 10 seconds...");
+    // Show Continue button — all status items are now populated.
+    splash_show_continue_button();
+
+    // 4. Hold splash up to 10 seconds; exit early if user taps Continue.
+    Serial.println("Booting: holding splash screen (max 10s)...");
     uint32_t wait_start = millis();
     while (millis() - wait_start < 10000) {
         esp_task_wdt_reset();
-        
-        // Keep updating WiFi status in case it connects during the 10s
+
+        if (splash_is_continue_pressed()) {
+            Serial.println("Splash: Continue tapped");
+            break;
+        }
+
+        // Keep updating WiFi status in case it connects during the wait
         static bool last_wifi_state = false;
         bool wifi_now = network.isConnected();
         if (wifi_now != last_wifi_state) {
@@ -91,7 +105,7 @@ void setup() {
             }
             last_wifi_state = wifi_now;
         }
-        
+
         lv_timer_handler();
         delay(20);
     }
@@ -102,12 +116,15 @@ void setup() {
     sysState.init();
     config.init();
     inventory.init();
+    Serial.printf("Mem[inventory]:  heap=%u  psram=%u\n", ESP.getFreeHeap(), ESP.getFreePsram());
     feedback.init();
 
     ui.init();
     // screenAbout is initialized inside UIManager::init() — do not double-init
     screenFilamentSelect.init();
     Serial.println("UI Initialized");
+    Serial.printf("Mem[ui]:         heap=%u  psram=%u  minHeap=%u\n",
+                  ESP.getFreeHeap(), ESP.getFreePsram(), ESP.getMinFreeHeap());
 }
 
 // --- Background RFID Task ---

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -28,13 +28,14 @@ void AppNetwork::process() {
 }
 
 bool AppNetwork::connect() {
-    // Try to connect with saved creds, non-blocking
+    // WiFi.SSID() only returns a value when already connected, NOT from NVS on cold
+    // boot — so don't gate on it. WiFi.begin() with no args reconnects to the last
+    // saved network from NVS regardless of current connection state.
+    WiFi.persistent(true);        // Ensure credentials are written to NVS on connect
+    WiFi.setAutoReconnect(true);  // Auto-reconnect if connection drops mid-session
     WiFi.mode(WIFI_STA);
-    if (WiFi.SSID().length() > 0) {
-        WiFi.begin();
-        return true;
-    }
-    return false;
+    WiFi.begin();                 // Reconnect using stored NVS credentials
+    return true;
 }
 
 void AppNetwork::startConfigPortal() {

--- a/src/rfid_driver.cpp
+++ b/src/rfid_driver.cpp
@@ -28,6 +28,12 @@ static char s_rawDump[1024] = {};
 // Populated only on a successful readCFSTag(); empty if no tag has been read yet.
 static char s_lastPayload[48] = {};
 
+// Last mirror read result — populated inside readCFSTag() immediately after payload read,
+// while the tag is still selected in the same MIFARE session.
+static MirrorResult s_lastMirrors = {};
+
+const MirrorResult& RFIDDriver::getLastMirrors() const { return s_lastMirrors; }
+
 const char* RFIDDriver::getLastRawDump() const { return s_rawDump; }
 const char* RFIDDriver::getLastPayload()  const { return s_lastPayload; }
 
@@ -106,7 +112,11 @@ bool RFIDDriver::authenticateSector(uint8_t sector) {
     if (!keyACached) {
         generateKeyA(currentUid, cachedKeyA);
         keyACached = true;
-        Serial.printf("Auth: derived key: %02X %02X %02X %02X %02X %02X\n",
+        // Log UID + derived key together so they can be cross-checked against
+        // reference tools (e.g. DnG-Crafts/K2-RFID for the same UID).
+        Serial.printf("Auth: UID");
+        for (uint8_t i = 0; i < currentUidLen; i++) Serial.printf(" %02X", currentUid[i]);
+        Serial.printf("  key: %02X %02X %02X %02X %02X %02X\n",
                       cachedKeyA[0], cachedKeyA[1], cachedKeyA[2],
                       cachedKeyA[3], cachedKeyA[4], cachedKeyA[5]);
     }
@@ -915,6 +925,19 @@ bool RFIDDriver::readCFSTag(SpoolData& spoolData) {
                       parsed.getRawData().c_str(),
                       parsed.getType().c_str(),
                       parsed.getWeight());
+
+        // Read mirror sectors (6-8) now, while tag is still selected in this session.
+        // Storing result so callers can retrieve remaining filament without a second session.
+        s_lastMirrors = readMirrors();
+        if (s_lastMirrors.valid) {
+            Serial.printf("Mirrors: remain=%umm / %ug  counter=%u\n",
+                          s_lastMirrors.data.remain_len_mm,
+                          s_lastMirrors.data.remain_weight_g,
+                          s_lastMirrors.data.update_counter);
+        } else {
+            Serial.println("Mirrors: unreadable (mutable sectors may use different keys)");
+        }
+
         return true;
     }
 

--- a/src/ui/screens/screen_about.cpp
+++ b/src/ui/screens/screen_about.cpp
@@ -11,7 +11,10 @@
 #include <Arduino.h>
 #include "esp_chip_info.h"
 #include <LittleFS.h>
+#include <WiFi.h>
 #include "board_pins.h"
+#include "network_manager.h"
+#include "rfid_driver.h"
 
 ScreenAbout screenAbout;
 
@@ -71,14 +74,16 @@ void ScreenAbout::init() {
         return lbl;
     };
 
-    labelBoard    = makeLabel(infoContainer);
-    labelDisplay  = makeLabel(infoContainer);
-    labelRFID     = makeLabel(infoContainer);
-    labelFWInfo   = makeLabel(infoContainer);
-    labelChipInfo = makeLabel(infoContainer);
-    labelMemInfo  = makeLabel(infoContainer);
-    labelFlashInfo = makeLabel(infoContainer);
+    labelBoard       = makeLabel(infoContainer);
+    labelDisplay     = makeLabel(infoContainer);
+    labelRFID        = makeLabel(infoContainer);
+    labelRFIDLive    = makeLabel(infoContainer);
+    labelFWInfo      = makeLabel(infoContainer);
+    labelChipInfo    = makeLabel(infoContainer);
+    labelMemInfo     = makeLabel(infoContainer);
+    labelFlashInfo   = makeLabel(infoContainer);
     labelStorageInfo = makeLabel(infoContainer);
+    labelWifiStatus  = makeLabel(infoContainer);
 
 }
 
@@ -119,9 +124,10 @@ void ScreenAbout::show() {
         chip_info.revision, chip_info.cores);
 
     // --- Memory ---
+    uint32_t psram_free_kb = ESP.getFreePsram() / 1024;
     lv_label_set_text_fmt(labelMemInfo,
-        LV_SYMBOL_REFRESH "  PSRAM %luMB OPI  |  Heap free %luKB",
-        (unsigned long)psram_mb, (unsigned long)heap_kb);
+        LV_SYMBOL_REFRESH "  PSRAM %luMB OPI (free %luKB)  |  Heap free %luKB",
+        (unsigned long)psram_mb, (unsigned long)psram_free_kb, (unsigned long)heap_kb);
 
     // --- Flash ---
     lv_label_set_text_fmt(labelFlashInfo,
@@ -137,6 +143,33 @@ void ScreenAbout::show() {
     } else {
         lv_label_set_text(labelStorageInfo,
             LV_SYMBOL_DIRECTORY "  LittleFS: not mounted");
+    }
+
+    // --- Live WiFi status ---
+    if (network.isConnected()) {
+        String ssid = WiFi.SSID();
+        String ip   = WiFi.localIP().toString();
+        lv_label_set_text_fmt(labelWifiStatus,
+            LV_SYMBOL_WIFI "  WiFi: %s  |  IP: %s",
+            ssid.c_str(), ip.c_str());
+        lv_obj_set_style_text_color(labelWifiStatus, lv_color_hex(0x44DD88), 0);
+    } else {
+        lv_label_set_text(labelWifiStatus, LV_SYMBOL_WIFI "  WiFi: Not connected");
+        lv_obj_set_style_text_color(labelWifiStatus, lv_color_hex(0xDD4444), 0);
+    }
+
+    // --- Live RFID status ---
+    uint32_t rfid_ver = rfid.getFirmwareVersion();
+    if (rfid_ver > 0) {
+        lv_label_set_text_fmt(labelRFIDLive,
+            LV_SYMBOL_CHARGE "  RFID: PN532 OK  |  IC=0x%02lX  ver=%lu.%lu",
+            (unsigned long)((rfid_ver >> 24) & 0xFF),
+            (unsigned long)((rfid_ver >> 16) & 0xFF),
+            (unsigned long)((rfid_ver >>  8) & 0xFF));
+        lv_obj_set_style_text_color(labelRFIDLive, lv_color_hex(0x44DD88), 0);
+    } else {
+        lv_label_set_text(labelRFIDLive, LV_SYMBOL_CHARGE "  RFID: PN532 not found");
+        lv_obj_set_style_text_color(labelRFIDLive, lv_color_hex(0xDD4444), 0);
     }
 
     lv_screen_load_anim(screen, LV_SCR_LOAD_ANIM_FADE_IN, 200, 0, false);

--- a/src/ui/screens/screen_main.cpp
+++ b/src/ui/screens/screen_main.cpp
@@ -64,8 +64,8 @@ void ScreenMain::init() {
     lv_obj_set_scrollbar_mode(screen, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_bg_color(screen, lv_color_white(), 0);
 
-    /* --- Grid: content row | grey line | bottom buttons (left/right/bottom = 3 regions) --- */
-    static lv_coord_t row_dsc[] = {LV_GRID_FR(1), 4, 100, LV_GRID_TEMPLATE_LAST};
+    /* --- Grid: status bar | content row | grey line | bottom buttons --- */
+    static lv_coord_t row_dsc[] = {24, LV_GRID_FR(1), 4, 100, LV_GRID_TEMPLATE_LAST};
     static lv_coord_t col_dsc[] = {LV_GRID_FR(1), 4, LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
     lv_obj_set_layout(screen, LV_LAYOUT_GRID);
     lv_obj_set_grid_dsc_array(screen, col_dsc, row_dsc);
@@ -73,19 +73,41 @@ void ScreenMain::init() {
     lv_obj_set_style_pad_row(screen, 0, 0);
     lv_obj_set_style_pad_column(screen, 0, 0);
 
-    /* --- Grey horizontal line above buttons --- */
+    /* --- Status bar (row 0, all 3 cols) --- */
+    statusBar = lv_obj_create(screen);
+    lv_obj_set_style_bg_color(statusBar, lv_color_hex(0x1E1E1E), 0);
+    lv_obj_set_style_border_width(statusBar, 0, 0);
+    lv_obj_set_style_radius(statusBar, 0, 0);
+    lv_obj_set_style_pad_hor(statusBar, 8, 0);
+    lv_obj_set_style_pad_ver(statusBar, 0, 0);
+    lv_obj_clear_flag(statusBar, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_grid_cell(statusBar, LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_flex_flow(statusBar, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(statusBar, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+    labelBattStatus = lv_label_create(statusBar);
+    lv_label_set_text(labelBattStatus, LV_SYMBOL_BATTERY_FULL);
+    lv_obj_set_style_text_font(labelBattStatus, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(labelBattStatus, lv_color_hex(0x808080), 0);
+
+    labelWifiStatus = lv_label_create(statusBar);
+    lv_label_set_text(labelWifiStatus, LV_SYMBOL_WIFI " No WiFi");
+    lv_obj_set_style_text_font(labelWifiStatus, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(labelWifiStatus, lv_color_hex(0x606060), 0);
+
+    /* --- Grey horizontal line above buttons (row 2) --- */
     lv_obj_t* lineH = lv_obj_create(screen);
     lv_obj_set_size(lineH, LV_PCT(100), 4);
     lv_obj_set_style_bg_color(lineH, lv_color_hex(0x808080), 0);
     lv_obj_set_style_border_width(lineH, 0, 0);
     lv_obj_set_style_radius(lineH, 0, 0);
-    lv_obj_set_grid_cell(lineH, LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 1, 1);
+    lv_obj_set_grid_cell(lineH, LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 2, 1);
 
-    /* --- Left area: color block (tap opens color picker) --- */
+    /* --- Left area: color block (tap opens color picker) (row 1) --- */
     lv_obj_t* leftPanel = lv_obj_create(screen);
     lv_obj_set_style_bg_opa(leftPanel, 0, 0);
     lv_obj_set_style_border_width(leftPanel, 0, 0);
-    lv_obj_set_grid_cell(leftPanel, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(leftPanel, LV_GRID_ALIGN_STRETCH, 0, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
     lv_obj_set_flex_flow(leftPanel, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(leftPanel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
 
@@ -103,19 +125,19 @@ void ScreenMain::init() {
     lv_obj_set_style_text_color(labelHexColor, lv_color_black(), 0);
     lv_obj_set_align(labelHexColor, LV_ALIGN_CENTER);
 
-    /* --- Vertical grey divider (content area only, not bottom) --- */
+    /* --- Vertical grey divider (content area only, row 1) --- */
     lv_obj_t* lineV = lv_obj_create(screen);
     lv_obj_set_size(lineV, 4, LV_PCT(100));
     lv_obj_set_style_bg_color(lineV, lv_color_hex(0x808080), 0);
     lv_obj_set_style_border_width(lineV, 0, 0);
     lv_obj_set_style_radius(lineV, 0, 0);
-    lv_obj_set_grid_cell(lineV, LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(lineV, LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
 
-    /* --- Right area: brand, type, volume --- */
+    /* --- Right area: brand, type, volume (row 1) --- */
     lv_obj_t* rightPanel = lv_obj_create(screen);
     lv_obj_set_style_bg_opa(rightPanel, 0, 0);
     lv_obj_set_style_border_width(rightPanel, 0, 0);
-    lv_obj_set_grid_cell(rightPanel, LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 0, 1);
+    lv_obj_set_grid_cell(rightPanel, LV_GRID_ALIGN_STRETCH, 2, 1, LV_GRID_ALIGN_STRETCH, 1, 1);
     lv_obj_set_flex_flow(rightPanel, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(rightPanel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_pad_all(rightPanel, 20, 0);
@@ -168,11 +190,11 @@ void ScreenMain::init() {
     lv_obj_set_style_text_font(labelWeight, &lv_font_montserrat_20, 0);
     lv_obj_set_style_text_color(labelWeight, lv_color_black(), 0);
 
-    /* --- Bottom region: status + Read, Write, Library, Settings (all visible) --- */
+    /* --- Bottom region: status + Read, Write, Library, Settings (row 3) --- */
     lv_obj_t* bottomArea = lv_obj_create(screen);
     lv_obj_set_style_bg_color(bottomArea, lv_color_hex(0xE8E8E8), 0);
     lv_obj_set_style_border_width(bottomArea, 0, 0);
-    lv_obj_set_grid_cell(bottomArea, LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 2, 1);
+    lv_obj_set_grid_cell(bottomArea, LV_GRID_ALIGN_STRETCH, 0, 3, LV_GRID_ALIGN_STRETCH, 3, 1);
     lv_obj_set_flex_flow(bottomArea, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(bottomArea, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_pad_all(bottomArea, 8, 0);
@@ -233,6 +255,23 @@ void ScreenMain::setWriteStatus(const char* status, bool success, bool neutral) 
         lv_obj_set_style_text_color(labelWriteStatus, lv_color_hex(0xC80000), 0);
     }
     lv_obj_invalidate(labelWriteStatus);
+}
+
+void ScreenMain::updateStatusBar(bool wifiConnected, int8_t rssi, const char* ssid) {
+    // Battery: static placeholder until ADC is wired; grey icon
+    lv_label_set_text(labelBattStatus, LV_SYMBOL_BATTERY_FULL);
+    lv_obj_set_style_text_color(labelBattStatus, lv_color_hex(0x808080), 0);
+
+    // WiFi: green + SSID when connected, grey when not
+    if (wifiConnected) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), LV_SYMBOL_WIFI " %.12s", ssid ? ssid : "");
+        lv_label_set_text(labelWifiStatus, buf);
+        lv_obj_set_style_text_color(labelWifiStatus, lv_color_hex(0x00C853), 0);
+    } else {
+        lv_label_set_text(labelWifiStatus, LV_SYMBOL_WIFI " No WiFi");
+        lv_obj_set_style_text_color(labelWifiStatus, lv_color_hex(0x606060), 0);
+    }
 }
 
 void ScreenMain::update(const SpoolData& data) {

--- a/src/ui/screens/screen_rfid_raw.cpp
+++ b/src/ui/screens/screen_rfid_raw.cpp
@@ -11,7 +11,7 @@ ScreenRfidRaw screenRfidRaw;
 // ---------------------------------------------------------------------------
 static constexpr int kColCount = 8;
 static const struct { const char* hdr; uint16_t w; } kCols[kColCount] = {
-    { "M DD YY",     100 },   // date  (pos 0-4)
+    { "Date",        100 },   // date  (pos 0-4)
     { "venderId",     90 },   // vendor (pos 5-8)
     { "batch",        70 },   // batch  (pos 9-10)
     { "filamentId",  110 },   // sep+type (pos 11-16)
@@ -132,11 +132,21 @@ void ScreenRfidRaw::populateTable(const char* payload) {
         return;
     }
 
-    char dateFmt[12], vendor[8], batch[8], matId[8], color[10], length[8], serial[8], reserve[8];
+    char dateFmt[16], vendor[8], batch[8], matId[8], color[10], length[8], serial[8], reserve[8];
 
-    // date (pos 0-4): reformat "MDDYY" → "M DD YY"
-    snprintf(dateFmt, sizeof(dateFmt), "%c %c%c %c%c",
-             payload[0], payload[1], payload[2], payload[3], payload[4]);
+    // date (pos 0-4): prefix(1) + month_hex(1) + day(1) + year_2(2)
+    // Month is a hex digit: '1'-'9' = Jan-Sep, 'A'=Oct, 'B'=Nov, 'C'=Dec.
+    {
+        static const char* kMon[13] = {
+            "?","Jan","Feb","Mar","Apr","May","Jun",
+            "Jul","Aug","Sep","Oct","Nov","Dec"
+        };
+        char mch = payload[1];
+        int mi = (mch >= '1' && mch <= '9') ? (mch - '0') :
+                 (mch >= 'A' && mch <= 'C') ? (mch - 'A' + 10) : 0;
+        snprintf(dateFmt, sizeof(dateFmt), "%s %c '%.2s",
+                 kMon[mi], payload[2], payload + 3);
+    }
 
     // vendor (pos 5-8): 4 chars as-is
     snprintf(vendor, sizeof(vendor), "%.4s", payload + 5);
@@ -147,8 +157,8 @@ void ScreenRfidRaw::populateTable(const char* payload) {
     // filamentId (pos 11-16): separator(1) + material type(5) = 6 chars
     snprintf(matId, sizeof(matId), "%.6s", payload + 11);
 
-    // color (pos 17-23): color prefix(1) + hex RGB(6) = 7 chars
-    snprintf(color, sizeof(color), "%.7s", payload + 17);
+    // color (pos 18-23): skip Creality's '0' prefix, show as XRRGGBB
+    snprintf(color, sizeof(color), "X%.6s", payload + 18);
 
     // length (pos 24-27): 4 chars as-is (mm × 10 or raw value)
     snprintf(length, sizeof(length), "%.4s", payload + 24);

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -395,11 +395,16 @@ void UIManager::event_handler(lv_event_t* e) {
             if (network.updateFilamentDB()) {
                 sysState.handleEvent(SystemEvent::DB_UPDATE_SUCCESS);
                 feedback.dbUpdateSuccess();
+                ui.updateButtonStates();
             } else {
                 sysState.handleEvent(SystemEvent::DB_UPDATE_FAILED);
                 feedback.dbUpdateFailed();
+                // Show error on Main so the user can see it and tap labelWriteStatus to dismiss.
+                // showMainScreen() preserves the status label in ERROR state.
+                ui.screenMain.setWriteStatus(
+                    sysState.getErrorContext().message.c_str(), false, false);
+                ui.showMainScreen();
             }
-            ui.updateButtonStates();
         }
         else if (obj == ui.screenSettings.btnSetupWifi) {
             sysState.handleEvent(SystemEvent::WIFI_CONFIG_REQUEST);
@@ -465,7 +470,11 @@ void UIManager::event_handler(lv_event_t* e) {
 
 void UIManager::showMainScreen() {
     updateDashboardFromSpool(currentSpool);
-    screenMain.setWriteStatus("Ready");
+    // Don't clear the status label when in ERROR — preserve the error message
+    // so the user can see it and tap to dismiss.
+    if (sysState.getCurrentState() != SystemState::ERROR) {
+        screenMain.setWriteStatus("Ready");
+    }
     screenMain.show();
     updateButtonStates();  // P1.9: sync button states on screen transition
 }

--- a/src/ui/ui_manager.cpp
+++ b/src/ui/ui_manager.cpp
@@ -551,6 +551,10 @@ void UIManager::updateDashboardFromSpool(const SpoolData& data) {
     screenMain.update(data);
 }
 
+void UIManager::updateStatusBar(bool wifiConnected, int8_t rssi, const char* ssid) {
+    screenMain.updateStatusBar(wifiConnected, rssi, ssid);
+}
+
 void UIManager::createOverlay() {
     layerTop = lv_display_get_layer_top(lv_display_get_default());
     lv_obj_clear_flag(layerTop, LV_OBJ_FLAG_SCROLLABLE);  /* prevent touch from scrolling whole screen */


### PR DESCRIPTION
## Summary

- All 9 hardware-observed bugs (Steps 1–7) fixed and validated on MaTouch ESP32-S3 V3.1
- RFID reads a real Creality spool reliably (Key A derivation confirmed correct)
- I2S audio working on V3.1 hardware (three-tone startup melody confirmed)
- Splash screen Continue button + live WiFi status polling during boot hold
- About screen shows live WiFi SSID/IP and PN532 status with colour coding
- State machine UI lockout fixed (ERROR state preserves label; DB fail navigates to Main)
- Mirror sectors (6–8) read in-session after payload read; confirmed Creality uses standard MIFARE key on mutable sectors; empty spool reads remain=0mm/0g
- RFID Raw screen: date decoded to human-readable format (e.g. `Dec 3 '25`); color shown as `XFFFFFF`
- Dead `brightness` field removed (Waveshare FSD remnant)
- Per-step heap/PSRAM boot logging added; PSRAM confirmed healthy (7424 KB free)
- TODO, CLAUDE.md, and RFID spec doc updated with findings and next milestones

## Test plan

- [x] Boot: startup melody plays, splash shows WiFi status + Continue button
- [x] RFID auto-read: Creality spool reads without auth failure, correct fields displayed
- [x] Mirror read: `remain=0mm/0g` on empty spool, standard key fallback working
- [x] Error recovery: ERROR state shows label, tap dismisses, no UI lockout
- [x] About screen: live WiFi SSID/IP and RFID status visible
- [x] Heap: PSRAM free ~7424 KB, internal heap ~68 KB (healthy)
- [ ] Write to blank MIFARE tag — Milestone 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)