### PR TITLE
ci: add restrict-main-source workflow

### DIFF
--- a/.github/workflows/restrict-main-source.yml
+++ b/.github/workflows/restrict-main-source.yml
@@ -1,0 +1,18 @@
+name: Restrict main to develop only
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require source branch to be develop
+        run: |
+          if [ "${{ github.head_ref }}" != "develop" ]; then
+            echo "❌ PRs to main are only accepted from develop."
+            echo "   Source branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+          echo "✅ Source branch is develop — OK"


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow that enforces PRs to `main` must originate from `develop`
- Fails with a clear error message if source branch is anything other than `develop`

## Test plan

- [ ] Open a PR from any branch other than `develop` → workflow fails
- [ ] This PR (from `develop`) → workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)